### PR TITLE
Change "import.vrm" to "import_scene.vrm"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,7 +29,7 @@ bl_info = {
 
 
 class ImportVRM(bpy.types.Operator,ImportHelper):
-    bl_idname = "import.vrm"
+    bl_idname = "import_scene.vrm"
     bl_label = "import VRM"
     bl_description = "import VRM"
     bl_options = {'REGISTER', 'UNDO'}


### PR DESCRIPTION
When trying to use the import command "bpy.ops.import.vrm()" inside the console it throws an error because import is a python operator. See here: https://i.imgur.com/7hQfYzo.png

Changing "import.vrm" to "import_scene.vrm" will fix this and has no other impact on this project.